### PR TITLE
add scheduled orders, gifts, and store settings support

### DIFF
--- a/src/Models/Enums/OrderStatus.php
+++ b/src/Models/Enums/OrderStatus.php
@@ -36,10 +36,12 @@ enum OrderStatus: string
     case Opened = 'opened';
 
     case Closed = 'closed';
-    
+
     case PriceReview = 'price_review';
 
     case Paid = 'paid';
+
+    case Scheduled = 'scheduled';
 
     /**
      *  Get all active statuses.
@@ -58,8 +60,9 @@ enum OrderStatus: string
             self::Preparing,
             self::Prepared,
             self::Accepted,
-            self::PriceReview ,
-            self::Paid ,
+            self::PriceReview,
+            self::Paid,
+            self::Scheduled,
         ]), 'value');
     }
 
@@ -74,6 +77,7 @@ enum OrderStatus: string
             self::Pending,
             self::InDelivery,
             self::InLocation,
+            self::Scheduled,
         ]), 'value');
     }
 
@@ -145,7 +149,7 @@ enum OrderStatus: string
             self::Rejected,
             self::Completed,
             self::Accepted,
-            self::PriceReview ,
+            self::PriceReview,
         ]), 'value');
     }
 

--- a/src/Models/LoyaltyPoint.php
+++ b/src/Models/LoyaltyPoint.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Saham\SharedLibs\Models;
+
+use MongoDB\Laravel\Eloquent\Model;
+use Carbon\Carbon;
+
+/**
+ * LoyaltyPoint Model
+ * Tracks points earned and redeemed by users per store
+ * 
+ * @property string $user_id
+ * @property string $store_id
+ * @property string $order_id
+ * @property int $points
+ * @property int $redeemed_points
+ * @property \Carbon\Carbon $expires_at
+ */
+class LoyaltyPoint extends Model
+{
+    protected $connection = 'mongodb';
+    protected $collection = 'loyalty_points';
+
+    protected $fillable = [
+        'user_id',
+        'store_id',
+        'order_id',
+        'points',          // Original points earned
+        'redeemed_points', // Points that were already used for coupons
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'user_id' => 'string',
+        'store_id' => 'string',
+        'order_id' => 'string',
+        'points' => 'integer',
+        'redeemed_points' => 'integer',
+        'expires_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'redeemed_points' => 0,
+    ];
+
+    /**
+     * Accessor for remaining points in a single record
+     */
+    public function getRemainingPointsAttribute(): int
+    {
+        return (int) ($this->points - ($this->redeemed_points ?? 0));
+    }
+
+    /**
+     * Helper to get user's available points for a store
+     */
+    public static function getUserStorePoints(string $userId, string $storeId): int
+    {
+        return (int) static::where('user_id', $userId)
+            ->where('store_id', $storeId)
+            ->valid()
+            ->get()
+            ->sum('remaining_points');
+    }
+
+    /**
+     * Scope for valid (non-expired and has remaining points)
+     */
+    public function scopeValid($query)
+    {
+        return $query->where('expires_at', '>', Carbon::now())
+            ->whereRaw([
+                '$expr' => [
+                    '$gt' => [
+                        '$points',
+                        ['$ifNull' => ['$redeemed_points', 0]]
+                    ]
+                ]
+            ]);
+    }
+
+    /**
+     * Scope for expired points
+     */
+    public function scopeExpired($query)
+    {
+        return $query->where('expires_at', '<=', Carbon::now());
+    }
+
+    /**
+     * Relationships
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class, 'store_id');
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class, 'order_id');
+    }
+}

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -22,6 +22,11 @@ use Saham\SharedLibs\Traits\HasStateMachines;
  * @property bool|null $cash_paid 999 occurrences
  * @property string|null $coupon 951 occurrences
  * @property string|null $coupon_type_discount 314 occurrences
+ * @property \Illuminate\Support\Carbon|null $scheduled_pickup_time
+ * @property bool $is_gift
+ * @property string|null $recipient_name
+ * @property string|null $recipient_phone
+ * @property string|null $recipient_address
  * @property \Illuminate\Support\Carbon|null $created_at 1000 occurrences
  * @property string|null $deliver_type 1000 occurrences
  * @property float|null $delivery_fee 1000 occurrences
@@ -169,6 +174,8 @@ use Saham\SharedLibs\Traits\HasStateMachines;
  */
 class Order extends BaseModel
 {
+
+
     use HasFactory;
     use HasNotes;
     use HasStateMachines;
@@ -188,6 +195,7 @@ class Order extends BaseModel
 
     protected $casts = [
         'ref_id' => 'string',
+        'scheduled_pickup_time' => 'datetime',
     ];
 
     public function scopeCurrentStatus($query, $status): Builder
@@ -203,6 +211,19 @@ class Order extends BaseModel
         }
 
         return $query;
+    }
+
+    public static function onlyActive(): array
+    {
+        return OrderStatus::onlyActive();
+    }
+
+    /**
+     * Get all statuses that are considered "in way" (active delivery).
+     */
+    public static function onlyInWay(): array
+    {
+        return OrderStatus::onlyInWay();
     }
 
     public function user(): BelongsTo

--- a/src/Models/Store.php
+++ b/src/Models/Store.php
@@ -15,6 +15,8 @@ use Saham\SharedLibs\Traits\HasNotes;
 use Saham\SharedLibs\Traits\HasPaymentTypes;
 use Saham\SharedLibs\Traits\HasWallet;
 use Saham\SharedLibs\Traits\Translatable;
+use App\Models\DeliveryIntegrationMapping;
+use App\Models\OrderIntegration;
 
 /**
  * @property mixed                                                                                      $id                      1000 occurrences

--- a/src/Models/Store.php
+++ b/src/Models/Store.php
@@ -170,6 +170,8 @@ use Saham\SharedLibs\Traits\Translatable;
  * @method static \MongoDB\Laravel\Eloquent\Builder<static>|Store where4($value)
  * @method static \MongoDB\Laravel\Eloquent\Builder<static>|Store where5($value)
  *
+ * @property array|null $delivery_integrations
+ * @property array|null $loyalty_settings
  * @mixin \Eloquent
  */
 class Store extends BaseModel
@@ -179,7 +181,7 @@ class Store extends BaseModel
     use HasWallet;
     use SoftDeletes;
     use HasPaymentTypes;
-    use HasNotes ;
+    use HasNotes;
 
     protected $translatable = ['name', 'desc'];
     protected $attributes   = [
@@ -254,6 +256,53 @@ class Store extends BaseModel
             ->orderByDesc('created_at')
             ->orderByDesc('show_first')
             ->get();
+    }
+
+    /**
+     * Get all delivery integration mappings for this store
+     *
+     * @return \MongoDB\Laravel\Relations\HasMany
+     */
+    public function deliveryIntegrationMappings(): HasMany
+    {
+        return $this->hasMany(DeliveryIntegrationMapping::class, 'store_id', '_id');
+    }
+
+    /**
+     * Get active delivery integration mappings only
+     *
+     * @return \MongoDB\Laravel\Relations\HasMany
+     */
+    public function activeDeliveryIntegrationMappings(): HasMany
+    {
+        return $this->hasMany(DeliveryIntegrationMapping::class, 'store_id', '_id')
+            ->where('is_active', true);
+    }
+
+    /**
+     * Check if store has any active integrations
+     *
+     * @return bool
+     */
+    public function hasActiveIntegrations(): bool
+    {
+        return $this->deliveryIntegrationMappings()
+            ->where('is_active', true)
+            ->exists();
+    }
+
+    /**
+     * Get integration mapping for specific provider
+     *
+     * @param string $provider
+     * @return DeliveryIntegrationMapping|null
+     */
+    public function getIntegrationMapping(string $provider): ?DeliveryIntegrationMapping
+    {
+        return $this->deliveryIntegrationMappings()
+            ->where('provider', $provider)
+            ->where('is_active', true)
+            ->first();
     }
 
     public function getFavorites(): ?int

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -132,8 +132,24 @@ class User extends Authenticatable
     ];
 
     protected $fillable = [
-        'cuisine_ids', 'phone', 'otp', 'device_id', 'device_type', 'os_version', 'notification_id', 'email', 'allowed_payment_methods',
-        'full_name', 'bank_iban', 'bank_name',  'referral_code', 'services', 'notes_history', 'block', 'password', 'gender',
+        'cuisine_ids',
+        'phone',
+        'otp',
+        'device_id',
+        'device_type',
+        'os_version',
+        'notification_id',
+        'email',
+        'allowed_payment_methods',
+        'full_name',
+        'bank_iban',
+        'bank_name',
+        'referral_code',
+        'services',
+        'notes_history',
+        'block',
+        'password',
+        'gender',
     ];
 
     public function findForPassport($username): ?self
@@ -159,6 +175,11 @@ class User extends Authenticatable
     public function delivers(): HasMany
     {
         return $this->hasMany(Deliver::class);
+    }
+
+    public function loyaltyPoints(): HasMany
+    {
+        return $this->hasMany(LoyaltyPoint::class, 'user_id');
     }
 
     public function orders(): HasMany

--- a/src/StateMachines/OrderStatusMachine.php
+++ b/src/StateMachines/OrderStatusMachine.php
@@ -32,61 +32,61 @@ class OrderStatusMachine extends BaseStateMachine
                 // handle pending transitions
                 OrderStatus::Pending->value => [
 
-                    OrderStatus::Accepted->value => fn ($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup([  'administrators'], $who),
+                    OrderStatus::Accepted->value => fn($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
-                    OrderStatus::Expired->value   => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', 'administrators'], $who),
+                    OrderStatus::Expired->value   => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who),
                 ],
 
                 // handle Accepted transitions
                 OrderStatus::Accepted->value => [
-                    OrderStatus::InLocation->value => fn ($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup([  'administrators'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', ], $who)
+                    OrderStatus::InLocation->value => fn($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users',], $who)
 
 
                 ],
                 // handle InLocation transitions
                 OrderStatus::InLocation->value => [
-                    OrderStatus::PriceReview->value => fn ($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup([  'administrators'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', ], $who)
+                    OrderStatus::PriceReview->value => fn($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users',], $who)
                 ],
 
-                  // handle InLocation transitions
-                  OrderStatus::PriceReview->value => [
-                    OrderStatus::Paid->value => fn ($model, $who) => $this->inGroup([ 'users', 'administrators'], $who) ,
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', 'administrators'], $who)
+                // handle InLocation transitions
+                OrderStatus::PriceReview->value => [
+                    OrderStatus::Paid->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who)
 
                 ],
                 OrderStatus::Paid->value => [
-                    OrderStatus::InDelivery->value => fn ($model, $who) => $this->inGroup(['drivers', 'administrators'], $who) ,
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup([  'administrators'], $who),
+                    OrderStatus::InDelivery->value => fn($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
                 ],
                 OrderStatus::InDelivery->value => [
-                    OrderStatus::Completed->value => fn ($model, $who) => $this->inGroup(['drivers', 'administrators'], $who) ,
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', 'administrators'], $who)
+                    OrderStatus::Completed->value => fn($model, $who) => $this->inGroup(['drivers', 'administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who)
 
                 ],
                 // handle rejected transitions
                 OrderStatus::Rejected->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle expired transitions
                 OrderStatus::Expired->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle cancelled transitions
                 OrderStatus::Cancelled->value => [
-                    OrderStatus::Refunded->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle refunded transitions
@@ -102,35 +102,35 @@ class OrderStatusMachine extends BaseStateMachine
                 // handle pending transitions
                 OrderStatus::Pending->value => [
 
-                    OrderStatus::Accepted->value => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
+                    OrderStatus::Accepted->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
 
-                    OrderStatus::Expired->value   => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', 'administrators'], $who),
+                    OrderStatus::Expired->value   => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who),
                 ],
 
                 // handle preparing transitions
                 OrderStatus::Accepted->value => [
-                    OrderStatus::Completed->value => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who)
+                    OrderStatus::Completed->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who)
                 ],
 
                 // handle rejected transitions
                 OrderStatus::Rejected->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle expired transitions
                 OrderStatus::Expired->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle cancelled transitions
                 OrderStatus::Cancelled->value => [
-                    OrderStatus::Refunded->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle refunded transitions
@@ -152,65 +152,65 @@ class OrderStatusMachine extends BaseStateMachine
 
                         return $this->inGroup(['managers', 'administrators', 'partners'], $who);
                     },
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
 
-                    OrderStatus::Expired->value   => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup(['users', 'administrators'], $who),
+                    OrderStatus::Expired->value   => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who),
                 ],
 
                 // handle preparing transitions
                 OrderStatus::Preparing->value => [
-                    OrderStatus::Prepared->value => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
-                    OrderStatus::Rejected->value => fn ($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Prepared->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
+                    OrderStatus::Rejected->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
                 ],
 
                 // handle prepared transitions
                 OrderStatus::Prepared->value => [
-                    OrderStatus::Completed->value  => fn ($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who) && $model->deliver_type === 'receipt',
-                    OrderStatus::InDelivery->value => fn ($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
+                    OrderStatus::Completed->value  => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who) && $model->deliver_type === 'receipt',
+                    OrderStatus::InDelivery->value => fn($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
 
-                    OrderStatus::Preparing->value => fn ($model, $who) => $this->inGroup(['administrators'], $who),
-                    OrderStatus::Rejected->value  => fn ($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Preparing->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Rejected->value  => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
                 ],
 
                 // handle in delivery transitions
                 OrderStatus::InDelivery->value => [
-                    OrderStatus::InLocation->value => fn ($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
+                    OrderStatus::InLocation->value => fn($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
 
-                    OrderStatus::Prepared->value  => fn ($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
-                    OrderStatus::Preparing->value => fn ($model, $who) => $this->inGroup(['administrators'], $who),
-                    OrderStatus::Rejected->value  => fn ($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Prepared->value  => fn($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
+                    OrderStatus::Preparing->value => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Rejected->value  => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
                 ],
 
                 // handle in location transitions
                 OrderStatus::InLocation->value => [
-                    OrderStatus::Completed->value => fn ($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
+                    OrderStatus::Completed->value => fn($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
 
-                    OrderStatus::InDelivery->value => fn ($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
-                    OrderStatus::Rejected->value   => fn ($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::InDelivery->value => fn($model, $who) => $this->inGroup(['opertional', 'administrators', 'drivers'], $who) && $model->deliver_type === 'delivery',
+                    OrderStatus::Rejected->value   => fn($model, $who) => $this->inGroup(['administrators'], $who),
 
                 ],
 
                 // handle rejected transitions
                 OrderStatus::Rejected->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle expired transitions
                 OrderStatus::Expired->value => [
-                    OrderStatus::Pending->value   => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Refunded->value  => fn ($model, $who) => $this->inGroup(['administrators', 'users'], $who),
-                    OrderStatus::Cancelled->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Pending->value   => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Refunded->value  => fn($model, $who) => $this->inGroup(['administrators', 'users'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle cancelled transitions
                 OrderStatus::Cancelled->value => [
-                    OrderStatus::Refunded->value => fn ($model, $who) => $this->inGroup([], $who),
+                    OrderStatus::Refunded->value => fn($model, $who) => $this->inGroup([], $who),
                 ],
 
                 // handle refunded transitions
@@ -218,6 +218,12 @@ class OrderStatusMachine extends BaseStateMachine
 
                 // handle completed transitions
                 OrderStatus::Completed->value => [],
+
+                OrderStatus::Scheduled->value => [
+                    OrderStatus::Pending->value => fn($model, $who) => true, // System can auto transition
+                    OrderStatus::Preparing->value => fn($model, $who) => $this->inGroup(['managers', 'administrators', 'partners'], $who),
+                    OrderStatus::Cancelled->value => fn($model, $who) => $this->inGroup(['users', 'administrators'], $who),
+                ],
 
             ];
         }


### PR DESCRIPTION
- OrderStatus: Added 'Scheduled' status to Enum and updated 'onlyActive'/'onlyInWay' helpers.
- StateMachine: Defined valid transitions for the 'Scheduled' status in 'OrderStatusMachine'.
- Order Model: Added properties for 'scheduled_pickup_time', 'gift_data', and recipient details. Refactored status methods to use Enum as the single source of truth.
- Store Model: Added property annotations for 'delivery_integrations' and 'loyalty_settings' to support new features.